### PR TITLE
Accept IdPs not known to FR (HostedIdP instances) in user authentication

### DIFF
--- a/app/federationregistry/fr-config.groovy.example
+++ b/app/federationregistry/fr-config.groovy.example
@@ -74,6 +74,7 @@ federation {
     cn = "cn"
     email= "mail"
     sharedToken = "auEduPersonSharedToken"
+    schacHomeOrganization = "schacHomeOrganization"
   }
 }
 

--- a/app/plugins/base/grails-app/controllers/aaf/fr/identity/AuthController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/identity/AuthController.groovy
@@ -74,6 +74,7 @@ class AuthController {
     attributes.cn =  federatedAttributeValue(grailsApplication, grailsApplication.config.federation.mapping.cn)
     attributes.email = federatedAttributeValue(grailsApplication, grailsApplication.config.federation.mapping.email)
     attributes.sharedToken = federatedAttributeValue(grailsApplication, grailsApplication.config.federation.mapping.sharedToken)
+    attributes.schacHomeOrganization = federatedAttributeValue(grailsApplication, grailsApplication.config.federation.mapping.schacHomeOrganization)
     
     if (!principal) {
       incomplete = true


### PR DESCRIPTION
Allow users coming in from Hosted IdP instances to log into FR - more pressing now with members migrating to Hosted IdP.

Besides deploying this code change, will require also:
* adding schacHomeOrganization to requested attributes
* adding mapping for  schacHomeOrganization in `fr_config.groovy` (managed in local deployment)

Already deployed in DEV (from a snapshot build) and working.