### PR TITLE
new: OrgAPI: extend export for compat with MDTool

### DIFF
--- a/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
+++ b/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
@@ -22,6 +22,7 @@ class OrganizationAPIv1Controller {
       // compatibility with SWAMID Metadata Tool
       result.active = org.functioning() // intentinoal duplicate
       result.memberSince = org.dateCreated.format("yyyy-MM-dd")
+      result.notMemberAfter = org.functioning() ? null : org.lastUpdated.format("yyyy-MM-dd")
       result.organizationInfoData = [
           en: [
                   OrganizationName: org.name,

--- a/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
+++ b/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
@@ -20,7 +20,7 @@ class OrganizationAPIv1Controller {
       result.link = g.createLink(controller: 'organizationAPIv1', id: org.id, absolute: true)
 
       // compatibility with SWAMID Metadata Tool
-      result.active = org.functioning() // intentinoal duplicate
+      result.active = result.functioning // intentional duplicate
       result.memberSince = org.dateCreated.format("yyyy-MM-dd")
       result.notMemberAfter = result.active ? null : org.lastUpdated.format("yyyy-MM-dd")
       result.organizationInfoData = [

--- a/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
+++ b/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
@@ -22,7 +22,7 @@ class OrganizationAPIv1Controller {
       // compatibility with SWAMID Metadata Tool
       result.active = org.functioning() // intentinoal duplicate
       result.memberSince = org.dateCreated.format("yyyy-MM-dd")
-      result.notMemberAfter = org.functioning() ? null : org.lastUpdated.format("yyyy-MM-dd")
+      result.notMemberAfter = result.active ? null : org.lastUpdated.format("yyyy-MM-dd")
       result.organizationInfoData = [
           en: [
                   OrganizationName: org.name,

--- a/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
+++ b/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/OrganizationAPIv1Controller.groovy
@@ -18,6 +18,17 @@ class OrganizationAPIv1Controller {
       result.functioning = org.functioning()
       result.archived = org.archived
       result.link = g.createLink(controller: 'organizationAPIv1', id: org.id, absolute: true)
+
+      // compatibility with SWAMID Metadata Tool
+      result.active = org.functioning() // intentinoal duplicate
+      result.memberSince = org.dateCreated.format("yyyy-MM-dd")
+      result.organizationInfoData = [
+          en: [
+                  OrganizationName: org.name,
+                  OrganizationDisplayName: org.displayName,
+                  OrganizationURL: org.url
+              ]
+          ]
       result.format = "json"
       results.add(result)
     }


### PR DESCRIPTION
Extend OrganizationAPI export to be compatible with the SWAMID Metadata Tool.

Consumers of the API will be adjusted to this new format, which will allow replacing FR with the Metadata Tool API.

This will link with https://github.com/SUNET/swamid-metadata-sp/pull/23 (data actually needed by downstream services will be provided by both).