### PR TITLE
new: include entityID in Services listing (MDtool compat)

### DIFF
--- a/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/ServiceCategoriesAPIv1Controller.groovy
+++ b/app/plugins/api/grails-app/controllers/aaf/fr/api/v1/ServiceCategoriesAPIv1Controller.groovy
@@ -52,6 +52,7 @@ class ServiceCategoriesAPIv1Controller {
 				def data = [:]
 				data.id = sp.id
 				data.displayName = sp.displayName
+				data.entityID = sp.entityDescriptor.entityID
 				data.description=sp.description
 				data.organization=sp.organization.displayName
 				data.organizationURL=sp.organization.url


### PR DESCRIPTION
To make it easier to import service URLs into MDTool, matching SPs by entityID.